### PR TITLE
Ueno/task show

### DIFF
--- a/app/Http/Controllers/Companies/TaskController.php
+++ b/app/Http/Controllers/Companies/TaskController.php
@@ -105,7 +105,7 @@ class TaskController extends Controller
 
     public function show($id)
     {
-        $task = Task::with(['project', 'taskCompanies.companyUser', 'taskPartners.partner'])->findOrFail($id);
+        $task = Task::findOrFail($id);
 
         $user = Auth::user();
         $company_user = CompanyUser::where('auth_id', $user->id)->get()->first();

--- a/database/seeds/ProjectCompaniesTableSeeder.php
+++ b/database/seeds/ProjectCompaniesTableSeeder.php
@@ -12,6 +12,6 @@ class ProjectCompaniesTableSeeder extends Seeder
     public function run()
     {
         $faker = Faker\Factory::create('ja_JP');
-        factory(App\Models\ProjectCompany::class, 10)->create(); 
+        factory(App\Models\ProjectCompany::class, 100)->create(); 
     }
 }

--- a/database/seeds/ProjectPartnersTableSeeder.php
+++ b/database/seeds/ProjectPartnersTableSeeder.php
@@ -12,6 +12,6 @@ class ProjectPartnersTableSeeder extends Seeder
     public function run()
     {
         $faker = Faker\Factory::create('ja_JP');
-        factory(App\Models\ProjectPartner::class, 10)->create(); 
+        factory(App\Models\ProjectPartner::class, 100)->create(); 
     }
 }

--- a/database/seeds/TaskCompaniesTableSeeder.php
+++ b/database/seeds/TaskCompaniesTableSeeder.php
@@ -7,6 +7,6 @@ class TaskCompaniesTableSeeder extends Seeder
     public function run()
     {
         $faker = Faker\Factory::create('ja_JP');
-        factory(App\Models\TaskCompany::class, 10)->create(); 
+        factory(App\Models\TaskCompany::class, 100)->create(); 
     }
 }

--- a/database/seeds/TaskPartnersTableSeeder.php
+++ b/database/seeds/TaskPartnersTableSeeder.php
@@ -12,6 +12,6 @@ class TaskPartnersTableSeeder extends Seeder
     public function run()
     {
         $faker = Faker\Factory::create('ja_JP');
-        factory(App\Models\TaskPartner::class, 10)->create(); 
+        factory(App\Models\TaskPartner::class, 100)->create(); 
     }
 }

--- a/resources/sass/company/task/show.scss
+++ b/resources/sass/company/task/show.scss
@@ -79,6 +79,10 @@
                 .imgbox{
                     width: 31px;
                     margin: 0 auto;
+
+                    img {
+                        border-radius: 50%;
+                    }
                 }
                 p{
                     margin-bottom: 0;
@@ -143,6 +147,10 @@
                 .imgbox{
                     width: 31px;
                     margin: 0 auto;
+
+                    img {
+                        border-radius: 50%;
+                    }
                 }
                 p{
                     margin-bottom: 0;

--- a/resources/views/company/task/show.blade.php
+++ b/resources/views/company/task/show.blade.php
@@ -84,21 +84,14 @@
                     担当者
                 </dt>
                 <dd class="flex01">
+                @foreach($task->taskCompanies as $taskCompany)
                     <div class="person-item">
                         <div class="imgbox">
-                            <img src="../../../images/photoimg.png" alt="">
+                            <img src="/{{ str_replace('public/', 'storage/', $taskCompany->companyUser->picture) }}" alt="担当者プロフィール画像">
                         </div>
-                        <p>@foreach($task->taskCompanies as $taskCompany)
-                                {{ $taskCompany->companyUser->name }}
-                            @endforeach
-                        </p>
+                        <p>{{ $taskCompany->companyUser->name }}</p>
                     </div>
-                    <div class="person-item">
-                        <div class="imgbox">
-                            <img src="../../../images/photoimg.png" alt="">
-                        </div>
-                        <p>永瀬達也</p>
-                    </div>
+                @endforeach
                 </dd>
             </dl>
             <dl>
@@ -106,18 +99,14 @@
                     上長
                 </dt>
                 <dd class="flex01">
+                @foreach($task->taskCompanies as $taskCompany)
                     <div class="person-item">
                         <div class="imgbox">
-                            <img src="../../../images/photoimg.png" alt="">
+                            <img src="/{{ str_replace('public/', 'storage/', $taskCompany->companyUser->picture) }}" alt="上長プロフィール画像">
                         </div>
-                        <p>永瀬達也</p>
+                        <p>{{ $taskCompany->companyUser->name }}</p>
                     </div>
-                    <div class="person-item">
-                        <div class="imgbox">
-                            <img src="../../../images/photoimg.png" alt="">
-                        </div>
-                        <p>永瀬達也</p>
-                    </div>
+                @endforeach
                 </dd>
             </dl>
             <dl class="term">
@@ -136,7 +125,7 @@
                     予算
                 </dt>
                 <dd>
-                    {{ $task->budget }}円
+                    {{ number_format($task->budget) }}円
                 </dd>
             </dl>
             <dl>
@@ -156,15 +145,14 @@
                     パートナー
                 </dt>
                 <dd class="flex01">
+                @foreach($task->taskPartners as $taskPartner)
                     <div class="person-item">
                         <div class="imgbox">
-                            <img src="../../../images/photoimg.png" alt="">
+                            <img src="/{{ str_replace('public/', 'storage/', $taskCompany->companyUser->picture) }}" alt="パートナープロフィール画像">
                         </div>
-                        <p>@foreach($task->taskPartners as $taskPartner)
-                                {{ $taskPartner->partner->name }}
-                            @endforeach
-                        </p>
+                        <p>{{ $taskPartner->partner->name }}</p>
                     </div>
+                @endforeach
                 </dd>
             </dl>
             <dl>
@@ -180,7 +168,7 @@
                     発注単価<span>(税抜)</span>
                 </dt>
                 <dd>
-                    12,000,000円
+                    {{ number_format($task->budget) }}円
                 </dd>
             </dl>
             <dl>
@@ -196,7 +184,7 @@
                     発注額
                 </dt>
                 <dd class="orderprice">
-                    <span class="tax">税込</span><span class="yen">￥</span>216,000 
+                    <span class="tax">税込</span><span class="yen">￥</span>{{ number_format($task->price * (1 + $task->tax)) }}
                 </dd>
             </dl>
             <dl>


### PR DESCRIPTION
## 概要
タスク詳細画面の担当者、上長、パートナーの表示の変更。
金額を3桁区切りにカンマで区切る。
担当者の存在しないtaskが多数存在したので、faker  dataの数を増やした。

## 確認項目
特になし

## 補足
