### PR TITLE
Fix forget password route in login page

### DIFF
--- a/resources/views/company/auth/login.blade.php
+++ b/resources/views/company/auth/login.blade.php
@@ -60,7 +60,7 @@
                 </div>
 
                 <div class="forget_password_wrapper">
-                    <a href="{{ route('password.request') }}">パスワードをお忘れの場合はこちら</a>
+                    <a href="#">パスワードをお忘れの場合はこちら</a>
                 </div>
                 
             </div>

--- a/resources/views/partner/auth/login.blade.php
+++ b/resources/views/partner/auth/login.blade.php
@@ -65,7 +65,7 @@
                 </div>
 
                 <div class="forget_password_wrapper">
-                    <a href="{{ route('password.request') }}">パスワードをお忘れの場合はこちら</a>
+                    <a href="#">パスワードをお忘れの場合はこちら</a>
                 </div>
                 
             </div>


### PR DESCRIPTION
## 概要
login画面でpasswordを忘れた際のリンクが未作成のため、linkを一旦＃に変更した。

## 確認項目
特になし

## 補足
