### PR TITLE
fix desplay_tax  purchaseOrder/show

### DIFF
--- a/app/Http/Controllers/Companies/Document/PurchaseOrderController.php
+++ b/app/Http/Controllers/Companies/Document/PurchaseOrderController.php
@@ -39,8 +39,6 @@ class PurchaseOrderController extends Controller
         $company = Company::findOrFail($companyUser->company_id);
         $tasks = Task::where('company_id', $company->id)->with(['taskPartners.partner'])->get();
 
-        $task = Task::findOrFail($request->task_id);
-
         $purchaseOrder = new PurchaseOrder;
         $purchaseOrder->company_id = $company->id;
         $purchaseOrder->companyUser_id       = $request->companyUser_id;
@@ -56,10 +54,11 @@ class PurchaseOrderController extends Controller
         $purchaseOrder->companyUser_name     = CompanyUser::findOrFail($request->companyUser_id)->name;
         $purchaseOrder->partner_name         = Partner::findOrFail($request->partner_id)->name;
         $purchaseOrder->task_name            = $request->task_name;
-        $purchaseOrder->task_delivery_format = Task::findOrFail($request->task_id)->delivery_format;
-        $purchaseOrder->task_ended_at        = Task::findOrFail($request->task_id)->ended_at;
-        $purchaseOrder->task_price           = Task::findOrFail($request->task_id)->price;
-        $purchaseOrder->task_tax             = Task::findOrFail($request->task_id)->tax;
+        $purchaseOrder->task_delivery_format = $request->task_delivery_format;
+        $task = Task::findOrFail($request->task_id);
+        $purchaseOrder->task_ended_at        = $task->ended_at;
+        $purchaseOrder->task_price           = $task->price;
+        $purchaseOrder->task_tax             = $task->tax;
         $purchaseOrder->save();
 
         return redirect()->route('company.document.purchaseOrder.show', [$purchaseOrder->id]);

--- a/app/Http/Controllers/Companies/Document/PurchaseOrderController.php
+++ b/app/Http/Controllers/Companies/Document/PurchaseOrderController.php
@@ -56,11 +56,10 @@ class PurchaseOrderController extends Controller
         $purchaseOrder->companyUser_name     = CompanyUser::findOrFail($request->companyUser_id)->name;
         $purchaseOrder->partner_name         = Partner::findOrFail($request->partner_id)->name;
         $purchaseOrder->task_name            = $request->task_name;
-        // $purchaseOrder->task_delivery_format = $task->delivery_format;
-        $purchaseOrder->task_delivery_format = 'email';
-        $purchaseOrder->task_ended_at        = $task->ended_at;
-        $purchaseOrder->task_price           = $task->price;
-        $purchaseOrder->task_tax             = $task->tax;
+        $purchaseOrder->task_delivery_format = Task::findOrFail($request->task_id)->delivery_format;
+        $purchaseOrder->task_ended_at        = Task::findOrFail($request->task_id)->ended_at;
+        $purchaseOrder->task_price           = Task::findOrFail($request->task_id)->price;
+        $purchaseOrder->task_tax             = Task::findOrFail($request->task_id)->tax;
         $purchaseOrder->save();
 
         return redirect()->route('company.document.purchaseOrder.show', [$purchaseOrder->id]);

--- a/database/migrations/2019_06_28_060438_create_purchase_orders_table.php
+++ b/database/migrations/2019_06_28_060438_create_purchase_orders_table.php
@@ -29,7 +29,7 @@ class CreatePurchaseOrdersTable extends Migration
             $table->string('task_delivery_format');
             $table->dateTime('task_ended_at');
             $table->integer('task_price');
-            $table->integer('task_tax');
+            $table->string('task_tax');
 
             $table->timestamps();
 

--- a/database/migrations/2019_06_28_060438_create_purchase_orders_table.php
+++ b/database/migrations/2019_06_28_060438_create_purchase_orders_table.php
@@ -29,7 +29,7 @@ class CreatePurchaseOrdersTable extends Migration
             $table->string('task_delivery_format');
             $table->dateTime('task_ended_at');
             $table->integer('task_price');
-            $table->string('task_tax');
+            $table->float('task_tax', 3, 2);
 
             $table->timestamps();
 

--- a/resources/views/company/document/purchaseOrder/show.blade.php
+++ b/resources/views/company/document/purchaseOrder/show.blade.php
@@ -144,65 +144,9 @@ const setPreview = (input) => {
                     <p>{{ number_format($purchaseOrder->task_price) }}</p>
                 </div>
 
-            <div class="order-container">
-                <table>
-                    <thead>
-                        <tr>
-                            <th>商品名</th>
-                            <th>数量</th>
-                            <th>単価</th>
-                            <th>合計</th>
-                        </tr>
-                    </thead>
-
-                    <tbody>
-                        <tr>
-                            <td>{{ $purchaseOrder->task_name }}</td>
-                            <td>1</td>
-                            <td>{{ number_format($purchaseOrder->task_price) }}</td>
-                            <td>{{ number_format($purchaseOrder->task_price) }}</td>
-                        </tr>
-                        <tr>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                        </tr>
-                        <tr>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                        </tr>
-                        <tr>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                        </tr>
-                    </tbody>
-                </table>
-
-                <div class="total-container">
-                    <div class="text-container">
-                        <p>合計</p>
-                    </div>
-
-                    <div class="section-container">
-                        <p class="sub-column">税抜</p>
-                        <p>{{ number_format($purchaseOrder->task_price) }}</p>
-                    </div>
-
-                    <div class="section-container">
-                        <p class="sub-column">消費税</p>
-                       
-                        <p>{{ $purchaseOrder->task_tax }}</p>
-                    </div>
-
-                    <div class="section-container">
-                        <p class="sub-column">総額</p>
-                        <p class="total-text">￥{{ number_format($purchaseOrder->task_price * (1 + $purchaseOrder->task_tax)) }}</p>
-                    </div>
+                <div class="section-container">
+                    <p class="sub-column">消費税</p>
+                    <p>{{ $purchaseOrder->task_tax }}</p>
                 </div>
 
                 <div class="section-container">

--- a/resources/views/company/document/purchaseOrder/show.blade.php
+++ b/resources/views/company/document/purchaseOrder/show.blade.php
@@ -146,7 +146,7 @@ const setPreview = (input) => {
 
                 <div class="section-container">
                     <p class="sub-column">消費税</p>
-                    <p>{{ $purchaseOrder->task_tax }}</p>
+                    <p>{{ number_format($purchaseOrder->task_price * ($purchaseOrder->task_tax)) }}</p>
                 </div>
 
                 <div class="section-container">

--- a/resources/views/company/document/purchaseOrder/show.blade.php
+++ b/resources/views/company/document/purchaseOrder/show.blade.php
@@ -144,9 +144,65 @@ const setPreview = (input) => {
                     <p>{{ number_format($purchaseOrder->task_price) }}</p>
                 </div>
 
-                <div class="section-container">
-                    <p class="sub-column">消費税</p>
-                    <p>{{ number_format($purchaseOrder->task->price * $purchaseOrder->task_tax) }}</p>
+            <div class="order-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>商品名</th>
+                            <th>数量</th>
+                            <th>単価</th>
+                            <th>合計</th>
+                        </tr>
+                    </thead>
+
+                    <tbody>
+                        <tr>
+                            <td>{{ $purchaseOrder->task_name }}</td>
+                            <td>1</td>
+                            <td>{{ number_format($purchaseOrder->task_price) }}</td>
+                            <td>{{ number_format($purchaseOrder->task_price) }}</td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <div class="total-container">
+                    <div class="text-container">
+                        <p>合計</p>
+                    </div>
+
+                    <div class="section-container">
+                        <p class="sub-column">税抜</p>
+                        <p>{{ number_format($purchaseOrder->task_price) }}</p>
+                    </div>
+
+                    <div class="section-container">
+                        <p class="sub-column">消費税</p>
+                       
+                        <p>{{ $purchaseOrder->task_tax }}</p>
+                    </div>
+
+                    <div class="section-container">
+                        <p class="sub-column">総額</p>
+                        <p class="total-text">￥{{ number_format($purchaseOrder->task_price * (1 + $purchaseOrder->task_tax)) }}</p>
+                    </div>
                 </div>
 
                 <div class="section-container">


### PR DESCRIPTION
## 概要
<!-- 変更の目的、内容等 -->
company/document/purchaseOrder/show の消費税表示箇所の修正

## 確認項目
<!-- 動作確認でチェックしてもらいたい項目 -->
・発注書詳細ページでの消費税表記に関する部分。

localhost:8888/company/document/purchaseOrder/{id}
＊{id}にはpurchase_oders_tableのidをお願いします。
もしくは
localhost:8888/company//document/purchaseOrder
から発注書を作成していただくと該当の発注書詳細ページが表示されますのでそちらから確認していただけます。

## 補足
<!-- レビュワーに見てもらいたい点等 -->
integerが少数点を含まないため探して「numeric」という型があったのですがlaravel側で使用できないというエラーが出たので他に少数を含む数値型が見つからなかったので現時点でstringで実装しました。