### PR TITLE
Fix condition shown button to change task status

### DIFF
--- a/app/Http/Controllers/Companies/TaskController.php
+++ b/app/Http/Controllers/Companies/TaskController.php
@@ -116,9 +116,16 @@ class TaskController extends Controller
         $company_user = CompanyUser::where('auth_id', $user->id)->get()->first();
         $companyUsers = CompanyUser::where('company_id', $company_user->company_id)->get();
 
+        $company_user_ids = array();
+        if ($task->taskCompanies) {
+            foreach($task->taskCompanies as $companyUser) {
+                array_push($company_user_ids, $companyUser->companyUser->id);
+            }
+        }
+
         $partners = Partner::where('company_id', $company_user->company_id)->get();
 
-        return view('/company/task/show', compact('task', 'project_count', 'companyUsers', 'partners', 'company_user', 'purchaseOrder', 'invoice'));
+        return view('/company/task/show', compact('task', 'project_count', 'companyUsers', 'partners', 'company_user', 'purchaseOrder', 'invoice', 'company_user_ids'));
     }
 
     public function edit($id)

--- a/resources/views/company/task/show.blade.php
+++ b/resources/views/company/task/show.blade.php
@@ -237,14 +237,14 @@
         </div>
         
         <div class="actionButton">
-            @if($task->status === 1 && $task->superior->id !== $company_user->id && $task->accounting->id !== $company_user->id)
+            @if($task->status === 1 && in_array($company_user->id, $company_user_ids))
                 <form action="{{ url('company/task/status') }}" method="POST">
                 @csrf
                     <input type="hidden" name="task_id" value="{{ $task->id }}">
                     <input type="hidden" name="status" value="2">
                     <button type="submit" class="done">上長に確認を依頼する</button>
                 </form>
-            @elseif($task->status === 2 && $task->superior->id === $company_user->id  && $task->accounting->id !== $company_user->id)
+            @elseif($task->status === 2 && $task->superior->id === $company_user->id)
                 <form action="{{ url('company/task/status') }}" method="POST">
                 @csrf
                     <input type="hidden" name="task_id" value="{{ $task->id }}">
@@ -257,39 +257,39 @@
                     <input type="hidden" name="status" value="3">
                     <button type="submit" class="done">タスクを承認する</button>
                 </form>
-            @elseif($task->status === 3 && $task->superior->id !== $company_user->id && $task->accounting->id !== $company_user->id)
+            @elseif($task->status === 3 && in_array($company_user->id, $company_user_ids))
                 <form action="{{ url('company/task/status') }}" method="POST">
                 @csrf
                     <input type="hidden" name="task_id" value="{{ $task->id }}">
                     <input type="hidden" name="status" value="4">
                     <button type="submit" class="done">パートナーに依頼する</button>
                 </form>
-            @elseif($task->status === 5 && $task->superior->id !== $company_user->id && $task->accounting->id !== $company_user->id)
+            @elseif($task->status === 5 && in_array($company_user->id, $company_user_ids))
                 <a href="/company/document/purchaseOrder/create/{{ $task->id }}" class="done">発注書を作成する</a>
-            @elseif($task->status === 6 && $task->superior->id !== $company_user->id && $task->accounting->id !== $company_user->id)
+            @elseif($task->status === 6 && in_array($company_user->id, $company_user_ids))
                 <form action="{{ url('company/task/status') }}" method="POST">
                 @csrf
                     <input type="hidden" name="task_id" value="{{ $task->id }}">
                     <input type="hidden" name="status" value="7">
                     <button type="submit" class="done">発注書の確認を上長に依頼する</button>
                 </form>
-            @elseif($task->status === 7 && $task->superior->id === $company_user->id  && $task->accounting->id !== $company_user->id)
+            @elseif($task->status === 7 && $task->superior->id === $company_user->id)
                 <a class="done" href="/company/document/purchaseOrder/{{ $purchaseOrder->id }}">発注書を確認する</a>
-            @elseif($task->status === 8 && $task->superior->id !== $company_user->id && $task->accounting->id !== $company_user->id)
+            @elseif($task->status === 8 && in_array($company_user->id, $company_user_ids))
                 <form action="{{ url('company/task/status') }}" method="POST">
                 @csrf
                     <input type="hidden" name="task_id" value="{{ $task->id }}">
                     <input type="hidden" name="status" value="9">
                     <button type="submit" class="done">発注書をパートナーに依頼する</button>
                 </form>
-            @elseif($task->status === 10 && $task->superior->id !== $company_user->id && $task->accounting->id !== $company_user->id)
+            @elseif($task->status === 10 && in_array($company_user->id, $company_user_ids))
                 <form action="{{ url('company/task/status') }}" method="POST">
                 @csrf
                     <input type="hidden" name="task_id" value="{{ $task->id }}">
                     <input type="hidden" name="status" value="11">
                     <button type="submit" class="done">請求書を依頼する</button>
                 </form>
-            @elseif($task->status === 12 && $task->superior->id !== $company_user->id && $task->accounting->id !== $company_user->id)
+            @elseif($task->status === 12 && in_array($company_user->id, $company_user_ids))
                 <a href="/company/document/invoice/{{ $invoice->id }}" class="done">請求書を確認する</a>
             @else
                 <p class="non-action-text">必要なアクションはありません</p>


### PR DESCRIPTION
## 概要
現状、タスクのステータスの切り替えにおいて、上長兼経理や上長兼担当者などは存在しないと考えていたため、それにしたがってステータスの変更ボタンを出し分けていたが、上長兼経理や上長兼担当者などがありえるとのことだったので、担当者であれば担当者に関連するボタン、上長であれば上長に関連するボタンを表示するように、ボタンの出し分けの仕様を変更した。

## 確認項目
上長兼経理や上長兼担当者などの兼用する場合でも問題なく、ステータスを変更することができるか。
taskを新規で作ってから確認お願いします。

## 補足
