### PR TITLE
Fix show partner image

### DIFF
--- a/resources/views/company/partner/index.blade.php
+++ b/resources/views/company/partner/index.blade.php
@@ -71,7 +71,7 @@
                         <div class="main-content">
                             <div class="main-content__img-container">
                                 <!-- <img class="main-content__img-container__img" src="" alt=""> -->
-                                <img src="../../../images/photoimg2.png" alt="">
+                                <img src="/{{ str_replace('public/', 'storage/', $partner->picture) }}"  alt="">
                             </div>
                             <div class="main-content__info-list">
                                 <div class="main-content__info-list__name">{{ $partner->name }}</div>


### PR DESCRIPTION
## 概要
パートナー一覧ページのパートナーのアイコンが表示されていなかったので修正。

## 確認項目
特になし

## 補足
