### PR TITLE
redirect to invoice register when creating invoice at no billing address

### DIFF
--- a/app/Http/Controllers/Partners/InvoiceController.php
+++ b/app/Http/Controllers/Partners/InvoiceController.php
@@ -12,6 +12,8 @@ use App\Models\CompanyUser;
 use App\Models\Company;
 use App\Models\RequestTask;
 use App\Models\RequestExpence;
+use App\Models\PartnerInvoice;
+
 use Illuminate\Support\Facades\Auth;
 
 class InvoiceController extends Controller
@@ -52,6 +54,13 @@ class InvoiceController extends Controller
     {
         $auth_id = Auth::user()->id;
         $partner = Partner::where('partner_id', $auth_id)->get()->first();
+        $partner_invoice = PartnerInvoice::where('partner_id', $partner->id)->get()->first();
+        if (!$partner_invoice) {
+            $completed = '';
+            $not_register_invoice = '請求情報が未登録のため、請求書の作成に失敗しました。請求情報を登録して、再度請求書を作成してください。';
+            return view('partner/setting/invoice/create', compact('partner', 'partner_invoice', 'completed', 'not_register_invoice'));
+        }
+
         $company_id = $partner->company_id;
 
         $invoice = new Invoice;

--- a/app/Http/Controllers/Partners/InvoiceController.php
+++ b/app/Http/Controllers/Partners/InvoiceController.php
@@ -57,8 +57,7 @@ class InvoiceController extends Controller
         $partner_invoice = PartnerInvoice::where('partner_id', $partner->id)->get()->first();
         if (!$partner_invoice) {
             $completed = '';
-            $not_register_invoice = '請求情報が未登録のため、請求書の作成に失敗しました。請求情報を登録して、再度請求書を作成してください。';
-            return view('partner/setting/invoice/create', compact('partner', 'partner_invoice', 'completed', 'not_register_invoice'));
+            return redirect()->route('partner.setting.invoice.create')->with('not_register_invoice', '請求情報が未登録のため、請求書の作成に失敗しました。請求情報を登録して、再度請求書を作成してください。');
         }
 
         $company_id = $partner->company_id;

--- a/app/Http/Controllers/Partners/Setting/InvoiceController.php
+++ b/app/Http/Controllers/Partners/Setting/InvoiceController.php
@@ -34,8 +34,7 @@ class InvoiceController extends Controller
         $partner_invoice = PartnerInvoice::where('partner_id', $partner->id)->get()->first();
 
         $completed = '';
-        $not_register_invoice = '';
-        return view('partner/setting/invoice/create', compact('partner', 'partner_invoice', 'completed', 'not_register_invoice'));
+        return view('partner/setting/invoice/create', compact('partner', 'partner_invoice', 'completed'));
     }
 
     /**
@@ -77,8 +76,7 @@ class InvoiceController extends Controller
         $partner_invoice = $new_partner_invoice;
 
         $completed = '変更を保存しました。';
-        $not_register_invoice = '';
-        return view('partner/setting/invoice/create', compact('partner', 'partner_invoice', 'completed', 'not_register_invoice'));
+        return view('partner/setting/invoice/create', compact('partner', 'partner_invoice', 'completed'));
     }
 
     /**

--- a/app/Http/Controllers/Partners/Setting/InvoiceController.php
+++ b/app/Http/Controllers/Partners/Setting/InvoiceController.php
@@ -34,7 +34,8 @@ class InvoiceController extends Controller
         $partner_invoice = PartnerInvoice::where('partner_id', $partner->id)->get()->first();
 
         $completed = '';
-        return view('partner/setting/invoice/create', compact('partner', 'partner_invoice', 'completed'));
+        $not_register_invoice = '';
+        return view('partner/setting/invoice/create', compact('partner', 'partner_invoice', 'completed', 'not_register_invoice'));
     }
 
     /**
@@ -76,7 +77,8 @@ class InvoiceController extends Controller
         $partner_invoice = $new_partner_invoice;
 
         $completed = '変更を保存しました。';
-        return view('partner/setting/invoice/create', compact('partner', 'partner_invoice', 'completed'));
+        $not_register_invoice = '';
+        return view('partner/setting/invoice/create', compact('partner', 'partner_invoice', 'completed', 'not_register_invoice'));
     }
 
     /**

--- a/resources/sass/partner/setting/invoice/index.scss
+++ b/resources/sass/partner/setting/invoice/index.scss
@@ -552,6 +552,10 @@
           opacity: 0.7;
           transition: 0.3s;
         }
+
+        .image-error_message {
+          margin-left: 20px;
+        }
       }
 
       .imprint-container {

--- a/resources/views/partner/setting/invoice/create.blade.php
+++ b/resources/views/partner/setting/invoice/create.blade.php
@@ -229,6 +229,12 @@ $pref = array(
 	</div>
   @endif
 
+	@if($not_register_invoice)
+	<div class="error-container">
+		<p>{{ $not_register_invoice }}</p>
+	</div>
+  @endif
+
 	<div class="title-container">
 		<h3>設定</h3>
 	</div>

--- a/resources/views/partner/setting/invoice/create.blade.php
+++ b/resources/views/partner/setting/invoice/create.blade.php
@@ -229,9 +229,9 @@ $pref = array(
 	</div>
   @endif
 
-	@if($not_register_invoice)
+	@if(Session::has('not_register_invoice'))
 	<div class="error-container">
-		<p>{{ $not_register_invoice }}</p>
+		<p>{{ session('not_register_invoice') }}</p>
 	</div>
   @endif
 
@@ -479,15 +479,17 @@ $pref = array(
 							<img id="preview" src="../../../images/upload3.png" alt="プレビュー画像">
 						</div>
 					@endif
+					<div>
 					<label for="mark_image">
 						画像をアップロード
 						<input type="file" id="mark_image" name="mark_image" style="display: none;" accept="image/png" onchange="setPreview(this)">
 					</label>
-				@if ($errors->has('mark_image'))
-					<div>
-						<strong style='color: #e3342f;'>{{ $errors->first('mark_image') }}</strong>
+					@if ($errors->has('mark_image'))
+						<div class="image-error_message">
+							<strong style='color: #e3342f;'>{{ $errors->first('mark_image') }}</strong>
+						</div>
+					@endif
 					</div>
-				@endif
 				</div>
 
 				<div class="imprint-container">


### PR DESCRIPTION
## 概要
請求情報が未登録時に請求書を作成するとエラーになっていたため、請求情報登録画面 redirect するように変更。

## 確認項目
請求情報未登録の partner が請求書を作成した時、　請求情報登録画面に redirect するか
請求情報未登録の partner が請求書の作成画面を経由せず、(sidebar の設定から) 請求情報を問題なく、作成できるか。

## 補足
