### PR TITLE
Komatus/error email verify

### DIFF
--- a/app/Http/Controllers/Companies/Registration/PersonalController.php
+++ b/app/Http/Controllers/Companies/Registration/PersonalController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers\Companies\Registration;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Companies\CompanyAndCompanyUserRequest;
+use App\Models\CompanyUser;
+
+
+class PersonalController extends Controller
+{
+    public function index()
+    {
+        //
+    }
+
+    public function create()
+    {
+        $auth = Auth::user();
+        $companyUser = CompanyUser::where('auth_id', $auth->id)->first();
+        
+        $request = '';
+
+        if(isset($companyUser)){
+            return  redirect('company/dashboard');
+        } else{
+            return view('company/auth/initialRegister/personal', compact('request'));
+        }
+    }
+
+    public function store(CompanyAndCompanyUserRequest $request)
+    {
+        $auth = Auth::user();
+        return view('company/auth/initialRegister/preview', compact('request'));
+    }
+
+    public function show($id)
+    {
+        //
+    }
+
+    public function edit($id)
+    {
+        //
+    }
+
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/Companies/Registration/PreRegisterController.php
+++ b/app/Http/Controllers/Companies/Registration/PreRegisterController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Companies\Registration;
+
+use App\Http\Controllers\Controller;
+use App\Models\CompanyUser;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+
+class PreRegisterController extends Controller
+{
+
+    public function __construct()
+    {
+        $this->middleware('guest:company');
+    }
+
+    
+    public function index()
+    {
+        $auth = Auth::user();
+        $companyUser = CompanyUser::where('auth_id', $auth->id)->first();
+        
+        if(isset($companyUser)){
+            return  redirect('company/dashboard');
+        } else{
+            return view('company/auth/verify');
+        }
+        return view('company/auth/verify');
+        }
+
+    public function create()
+    {
+        //
+    }
+
+    public function store(Request $request)
+    {
+        //
+    }
+
+    public function show($id)
+    {
+        //
+    }
+
+    public function edit($id)
+    {
+        //
+    }
+
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/Companies/Registration/PreRegisterController.php
+++ b/app/Http/Controllers/Companies/Registration/PreRegisterController.php
@@ -10,25 +10,10 @@ use Illuminate\Support\Facades\Auth;
 
 class PreRegisterController extends Controller
 {
-
-    public function __construct()
-    {
-        $this->middleware('guest:company');
-    }
-
-    
     public function index()
     {
-        $auth = Auth::user();
-        $companyUser = CompanyUser::where('auth_id', $auth->id)->first();
-        
-        if(isset($companyUser)){
-            return  redirect('company/dashboard');
-        } else{
-            return view('company/auth/verify');
-        }
         return view('company/auth/verify');
-        }
+    }
 
     public function create()
     {

--- a/app/Http/Controllers/Companies/Registration/PreviewController.php
+++ b/app/Http/Controllers/Companies/Registration/PreviewController.php
@@ -1,46 +1,34 @@
 <?php
 
-namespace App\Http\Controllers\Companies;
+namespace App\Http\Controllers\Companies\Registration;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Companies\CompanyAndCompanyUserRequest;
 use App\Models\Company;
 use App\Models\CompanyUser;
 
-class InitialRegisterController extends Controller
+class PreviewController extends Controller
 {
-    public function doneVerify()
+    public function index()
     {
-        $auth = Auth::user();
-        $companyUser = CompanyUser::where('auth_id', $auth->id)->first();
-        
-        if(isset($companyUser)){
-            return  redirect('company/dashboard');
-        } else{
-            return view('company/auth/initialRegister/doneVerify' ,compact('companyUser'));
-        }
+        // 
     }
+
 
     public function create()
     {
         $auth = Auth::user();
+        $companyUser = CompanyUser::where('auth_id', $auth->id)->first();
+        
         $request = '';
-        return view('company/auth/initialRegister/personal', compact('request'));
-    }
 
-    public function toPreview(CompanyAndCompanyUserRequest $request)
-    {
-        $auth = Auth::user();
-        return view('company/auth/initialRegister/preview', compact('request'));
+        if(isset($companyUser)){
+            return  redirect('company/dashboard');
+        } else{
+            return view('company/auth/initialRegister/preview', compact('request'));
+        }
     }
-
-    // public function previwShow(Request $request)
-    // {
-    //     $auth = Auth::user();
-    //     return view('company/auth/initialRegister/preview', compact('request'));
-    // }
 
     public function store(Request $request)
     {
@@ -80,9 +68,24 @@ class InitialRegisterController extends Controller
 
         return view('company/auth/initialRegister/done');
     }
-    
-    public function done()
+
+    public function show($id)
     {
-        return view('company/auth/regitster/done');
+        //
+    }
+
+    public function edit($id)
+    {
+        //
+    }
+
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    public function destroy($id)
+    {
+        //
     }
 }

--- a/app/Http/Controllers/Partners/InitialRegisterController.php
+++ b/app/Http/Controllers/Partners/InitialRegisterController.php
@@ -13,17 +13,26 @@ class InitialRegisterController extends Controller
 {
     public function doneVerify()
     {
-        return view('partner/auth/initialRegister/doneVerify', compact('company_id'));
+        $partnerAuth = Auth::user();
+        $partner = Partner::where('partner_id', $partnerAuth->id)->first();
+        
+        if(isset($partner)){
+            return  redirect('partner/dashboard');
+        } else{
+            return view('partner/auth/initialRegister/doneVerify', compact('company_id'));
+        }
     }
 
     public function createPartner()
     {
-        return view('partner/auth/initialRegister/personal');
-    }
-
-    public function toCreatePartner(Request $request)    
-    {
-        return view('partner/auth/initialRegister/personal', compact('request'));
+        $partnerAuth = Auth::user();
+        $partner = Partner::where('partner_id', $partnerAuth->id)->first();
+        
+        if(isset($partner)){
+            return  redirect('partner/dashboard');
+        } else{
+            return view('partner/auth/initialRegister/personal');
+        }
     }
 
     public function preview(PartnerRequest $request)
@@ -34,7 +43,14 @@ class InitialRegisterController extends Controller
     public function previwShow(Request $request)
     {
         $partnerAuth = Auth::user();
-        return view('partner/auth/initialRegister/preview', compact('request'));
+        $partner = Partner::where('partner_id', $partnerAuth->id)->first();
+        
+        if(isset($partner)){
+            return  redirect('partner/dashboard');
+        } else{
+            return view('partner/auth/initialRegister/preview', compact('request'));
+        }
+        
     }
 
     public function previewStore(Request $request)

--- a/app/Http/Controllers/Partners/InitialRegisterController.php
+++ b/app/Http/Controllers/Partners/InitialRegisterController.php
@@ -11,11 +11,7 @@ use App\Models\Partner;
 
 class InitialRegisterController extends Controller
 {
-    public function preRegisteredShow()
-    {
-        return view('partner/auth/verify');
-    }
-    public function doneVerifyShow()
+    public function doneVerify()
     {
         return view('partner/auth/initialRegister/doneVerify', compact('company_id'));
     }

--- a/app/Http/Controllers/Partners/Registration/PreRegisterController.php
+++ b/app/Http/Controllers/Partners/Registration/PreRegisterController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Partners\Registration;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+
+class PreRegisterController extends Controller
+{
+    public function index()
+    {
+        return view('partner/auth/verify');
+    }
+
+    public function create()
+    {
+        //
+    }
+
+    public function store(Request $request)
+    {
+        //
+    }
+
+    public function show($id)
+    {
+        //
+    }
+
+    public function edit($id)
+    {
+        //
+    }
+
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -21,7 +21,7 @@ class RedirectIfAuthenticated
             return redirect('/partner/dashboard');
         }
         if ($guard == "company" && Auth::guard($guard)->check()) {
-            return redirect('/company/dashbord');
+            return redirect('/company/dashboard');
         }
         if (Auth::guard($guard)->check()) {
             return redirect('/home');

--- a/resources/views/company/auth/initialRegister/doneVerify.blade.php
+++ b/resources/views/company/auth/initialRegister/doneVerify.blade.php
@@ -25,7 +25,7 @@
                 @if(isset($companyUser))
                     <a href="/company/dashboard">ダッシュボードに行く</a>
                 @else
-                    <a href="/company/register/intialRegistration">ユーザー情報を登録する</a>
+                    <a href="/company/register/personal">ユーザー情報を登録する</a>
                 @endif
 			</div>
 		</div>

--- a/resources/views/company/auth/initialRegister/personal.blade.php
+++ b/resources/views/company/auth/initialRegister/personal.blade.php
@@ -92,7 +92,7 @@ $pref = array(
 				<h3>企業情報登録</h3>
 			</div>
 
-			<form action="/company/register/initialRegistration" method="POST" enctype="multipart/form-data">
+			<form action="/company/register/personal" method="POST" enctype="multipart/form-data">
 				@csrf
 
 				<div class="edit-container-company">

--- a/resources/views/company/auth/initialRegister/preview.blade.php
+++ b/resources/views/company/auth/initialRegister/preview.blade.php
@@ -21,7 +21,7 @@
 				<h3>入力内容確認</h3>
 			</div>
 
-			<form action="/company/register/preview/previewStore" method="POST" enctype="multipart/form-data">
+			<form action="/company/register/preview" method="POST" enctype="multipart/form-data">
 				@csrf
 				<input type="hidden" name="">
 				<div class="edit-container">

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,7 +23,7 @@ Route::group(['prefix' => 'partner'], function(){
 	Route::post('register/{company_id}', 'Partners\Auth\RegisterController@register')->name('partner.register');
 
 	// preRegister
-	Route::get('register/preRegistered', 'Partners\InitialRegisterController@preRegisteredShow')->name('company.register.preRegisterd.preRegisteredShow');
+	Route::get('register/preRegistered', 'Partners\Registration\PreRegisterController@index')->name('company.register.preRegisterd.index');
 
 	// invite
 	Route::get('invite/register/reset/password', 'Partners\InitialRegisterController@resetPassword')->name('partner.invite.register.reset.password');
@@ -35,7 +35,7 @@ Route::group(['prefix' => 'partner'], function(){
 	
 	Route::group(['middleware' => ['partnerVerified:partner', 'auth:partner']], function() {
 		// register_flow
-		Route::get('/register/doneVerify', 'Partners\InitialRegisterController@doneVerifyShow')->name('partner.register.doneVerify.doneVerify');
+		Route::get('/register/doneVerify', 'Partners\InitialRegisterController@doneVerify')->name('partner.register.doneVerify.doneVerify');
 		Route::get('/register/initialRegistration', 'Partners\InitialRegisterController@createPartner')->name('partner.register.intialRegistration.createPartner');
 		Route::post('/register/initial/personal', 'Partners\InitialRegisterController@preview')->name('partner.register.intialRegistrationPost');
 		Route::get('/register/preview/previwShow', 'Partners\InitialRegisterController@previwShow')->name('parnter.register.preview.previwShow');
@@ -97,8 +97,10 @@ Route::group(['prefix' => 'company'], function(){
 		Route::post('/register/personal', 'Companies\Registration\PersonalController@store')->name('company.register.personal.store');
 		Route::get('/register/preview', 'Companies\Registration\PreviewController@create')->name('company.register.preview.create');
 		Route::post('/register/preview', 'Companies\Registration\PreviewController@store')->name('company.register.preview.store');
+		
 		// dashboard
 		Route::get('/dashboard', 'Companies\DashboardController@index')->name('company.dashboard');
+		
 		// project
 		Route::get('/project', 'Companies\ProjectController@index')->name('company.project.index');
 		Route::get('/project/create', 'Companies\ProjectController@create')->name('company.project.create');

--- a/routes/web.php
+++ b/routes/web.php
@@ -77,7 +77,9 @@ Route::group(['prefix' => 'company'], function(){
 	//register
 	Route::get('register', 'Companies\Auth\RegisterController@showRegisterForm')->name('company.register');
 	Route::post('register', 'Companies\Auth\RegisterController@register')->name('company.register');
-	Route::get('/register/preRegistered', 'Companies\InitialRegisterController@preRegisteredShow')->name('company.register.preRegisterd.preRegisteredShow');
+	
+	// preRegister
+	Route::get('/register/preRegistered', 'Companies\Registration\PreRegisterController@index')->name('company.register.preRegisterd.index');
 
 
 	// emailverify
@@ -88,11 +90,11 @@ Route::group(['prefix' => 'company'], function(){
 	Route::group(['middleware' => ['verified:company', 'auth:company']], function() {
 		
 		// register_flow
-		Route::get('/register/doneVerify', 'Companies\InitialRegisterController@doneVerifyShow')->name('company.register.doneVerify.doneVerifyShow');
-		Route::get('/register/intialRegistration', 'Companies\InitialRegisterController@create')->name('company.register.intialRegistration.create');
-		Route::post('/register/initialRegistration', 'Companies\InitialRegisterController@toPreview')->name('company.registerInfo.toPreview');
-		Route::get('/register/preview/previwShow', 'Companies\InitialRegisterController@previewShow')->name('company.register.preview.previwShow');
-		Route::post('/register/preview/previewStore', 'Companies\InitialRegisterController@previewStore')->name('company.register.preview.previewStore');
+		Route::get('/register/doneVerify', 'Companies\InitialRegisterController@doneVerify')->name('company.register.doneVerify');
+		Route::get('/register/personal', 'Companies\Registration\PersonalController@create')->name('company.register.personal.create');
+		Route::post('/register/personal', 'Companies\Registration\PersonalController@store')->name('company.register.personal.store');
+		Route::get('/register/preview', 'Companies\Registration\PreviewController@create')->name('company.register.preview.create');
+		Route::post('/register/preview', 'Companies\Registration\PreviewController@store')->name('company.register.preview.store');
 		Route::get('/regitster/done', 'Companies\InitialRegisterController@done')->name('company.register.done');
 		// dashboard
 		Route::get('/dashboard', 'Companies\DashboardController@index')->name('company.dashboard');
@@ -153,12 +155,6 @@ Route::group(['prefix' => 'company'], function(){
 		// mail(Partner)
 		Route::get('/userMail', 'Companies\PartnerMailController@index')->name('company.userMail.index');
 		Route::post('/mail/partner-send', 'Companies\PartnerMailController@send')->name('company.mail.partner-send');
-		
-		// personal register
-		Route::get('register/personal', 'Companies\InitialRegisterController@personal')->name('company.register.personal');
-		Route::get('register/company', 'Companies\InitialRegisterController@company')->name('company.register.company');
-		Route::get('register/preview', 'Companies\InitialRegisterController@preview')->name('company.register.preview');
-		Route::get('register/done', 'Companies\InitialRegisterController@done')->name('company.register.done');
 
 		// invite
 		Route::get('invite/partner', 'Companies\Invite\InvitePartnerController@index')->name('company.invite.partner.index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,8 @@ Route::group(['prefix' => 'partner'], function(){
 	//register
 	Route::get('register/{company_id}/{email}', 'Partners\Auth\RegisterController@showRegisterForm')->name('partner.register');
 	Route::post('register/{company_id}', 'Partners\Auth\RegisterController@register')->name('partner.register');
+
+	// preRegister
 	Route::get('register/preRegistered', 'Partners\InitialRegisterController@preRegisteredShow')->name('company.register.preRegisterd.preRegisteredShow');
 
 	// invite
@@ -95,7 +97,6 @@ Route::group(['prefix' => 'company'], function(){
 		Route::post('/register/personal', 'Companies\Registration\PersonalController@store')->name('company.register.personal.store');
 		Route::get('/register/preview', 'Companies\Registration\PreviewController@create')->name('company.register.preview.create');
 		Route::post('/register/preview', 'Companies\Registration\PreviewController@store')->name('company.register.preview.store');
-		Route::get('/regitster/done', 'Companies\InitialRegisterController@done')->name('company.register.done');
 		// dashboard
 		Route::get('/dashboard', 'Companies\DashboardController@index')->name('company.dashboard');
 		// project


### PR DESCRIPTION
## 概要
<!-- 変更の目的、内容等 -->
email_verify が完了しても url を叩くと email_verify を要求するページに遷移できてしまうエラー、ダッシュボードの綴りミスの修正

## 確認項目
<!-- 動作確認でチェックしてもらいたい項目 -->
担当者の登録フロー
http://localhost:8888/company/register
より、登録して問題なくダッシュボードまでいけるか。
また、ログイン時、未ログイン時に登録フローのURLを直接入力した時の挙動
http://localhost:8888/company/register/doneVerify
http://localhost:8888/company/register/personal
http://localhost:8888/company/register/preview

＊http://localhost:8888/company/register/preRegistered
はログイン時、未ログイン時ともに見にいけてしまいます。挙動としては
「 ここをクリックして別のメールをリクエストしてください。」で
login状態 -> ダッシュボード
未login状態 -> ログインページ
となります。

## 補足
<!-- レビュワーに見てもらいたい点等 -->
パートナー側は不明な問題を抱えているため微修正(PreRegiserのcontroller追加のみ)にとどめてあります。view(メール認証完了画面、登録ページ、プレビューページ、完了画面)は表示されないようになっていますが、postは直接叩けてしまします。(その時に意図しないエラー表示)