### PR TITLE
fix pdf css

### DIFF
--- a/resources/sass/company/document/invoice/show.scss
+++ b/resources/sass/company/document/invoice/show.scss
@@ -4,7 +4,6 @@
   padding: 40px;
   font-family: 'Source Sans Pro';
   .title-container {
-  margin-bottom: 50px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -13,6 +12,7 @@
     color: #43425d;
     margin-bottom: 0;
     font-size: 28px;
+    padding: 24px 0;
   }
   
   button {
@@ -21,8 +21,8 @@
     border: 2px solid #43425d;
     border-radius: 100px;
     font-weight: bold;
-    font-size: 16px;
-    padding: 6px 45px;
+    font-size: 18px;
+    padding: 4px;
     width: 140px;
   }
   button:hover {
@@ -36,7 +36,9 @@
   &__wrapper{
     margin: auto;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
+    margin-bottom: 30px;
     .title-container {
+      margin-bottom: 40px;
       h4 {
         font-size: 28px;
         width: 100%;

--- a/resources/sass/company/document/purchaseOrder/show.scss
+++ b/resources/sass/company/document/purchaseOrder/show.scss
@@ -54,6 +54,7 @@
     
           h4 {
             color: #43425d;
+            font-size: 28px;
           }
         }
     
@@ -64,6 +65,7 @@
     
           h4 {
             color: #43425d;
+            font-size: 28px;
           }
         }
     
@@ -204,6 +206,9 @@
     
             span {
               font-size: 12px;
+              margin-left: 5px;
+              margin-top: 8px;
+              display: block;
             }
           }
         }

--- a/resources/sass/partner/document/invoice/show.scss
+++ b/resources/sass/partner/document/invoice/show.scss
@@ -4,7 +4,6 @@
 	padding: 40px;
 
 	.title-container {
-    margin-bottom: 40px;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -14,15 +13,19 @@
       color: #43425d;
       margin-bottom: 0;
       font-size: 28px;
+      padding: 24px 0;
     }
     
     button {
-      color: #43425d;
+      padding: 4px;
+      width: 140px;
       background-color: #fff;
-      border: 1px solid #43425d;
-      border-radius: 48px;
+      color: #43425D;
+      margin: 24px 0;
+      border-radius: 100px;
+      border: 2px solid #43425D;
+      font-size: 18px;
       font-weight: bold;
-      padding: 8px 40px;
     }
 
     button:hover {
@@ -33,18 +36,20 @@
 
   .document-container {
     width: 100%;
-    padding: 48px;
     margin-bottom: 24px;
 
     &__wrapper{
       margin: auto;
+      margin-bottom: 30px;
 
       .title-container {
+        margin-bottom: 40px;
         h4 {
-          font-size: 20px;
+          font-size: 28px;
           width: 100%;
           text-align: right;
           color: #43425d;
+          margin-bottom: 0;
         }
       }
   
@@ -58,7 +63,10 @@
           text-align: left;
   
           p {
-            margin-bottom: 8px;
+            margin-bottom: 0;
+            font-size: 20px;
+            color: #43425D;
+            line-height: 40px;
           }
         }
   
@@ -68,7 +76,10 @@
           text-align: right;
   
           p {
-            margin-bottom: 8px;
+            margin-bottom: 0;
+            font-size: 13px;
+            color: #4D4F5C;
+            line-height: 23px;
           }
         }
       }
@@ -177,6 +188,9 @@
   
           span {
             font-size: 12px;
+            margin-left: 5px;
+            margin-top: 8px;
+            display: block;
           }
         }
       }

--- a/resources/views/company/document/invoice/show.blade.php
+++ b/resources/views/company/document/invoice/show.blade.php
@@ -159,10 +159,8 @@
 <div class="main-wrapper">
 	<div class="title-container">
 		<h3>請求書プレビュー</h3>
-​
-		<button id="print_btn" type="button">印刷</button>
+		<button id="print_btn" type="button">プリント</button>
 	</div>
-​
 	<div id="print" class="document-container A4">
         <!-- 印刷用 -->
 		<div class="pageout">
@@ -215,6 +213,36 @@
                                     <td>{{ number_format($requestExpence->total) }}</td>
                                 </tr>
                             @endforeach
+                            <tr>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                            </tr>
+                            <tr>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                            </tr>
+                            <tr>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                            </tr>
+                            <tr>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                            </tr>
+                            <tr>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                            </tr>
                             <tr>
                                 <td></td>
                                 <td></td>
@@ -338,6 +366,36 @@
 							<td></td>
 						</tr>
 						<tr>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+                        </tr>
+                        <tr>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+                        </tr>
+                        <tr>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+                        </tr>
+                        <tr>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+                        </tr>
+                        <tr>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+                        </tr>
+                        <tr>
 							<td></td>
 							<td></td>
 							<td></td>

--- a/resources/views/company/document/purchaseOrder/show.blade.php
+++ b/resources/views/company/document/purchaseOrder/show.blade.php
@@ -248,6 +248,42 @@ const setPreview = (input) => {
                                     <td></td>
                                     <td></td>
                                 </tr>
+                                    <tr>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                </tr>
+                                <tr>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                </tr>
+                                <tr>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                </tr>
+                                <tr>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                </tr>
+                                <tr>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                </tr>
+                                <tr>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                </tr>
                             </tbody>
                         </table>
         
@@ -324,6 +360,42 @@ const setPreview = (input) => {
                                 <td>1</td>
                                 <td>{{ number_format($purchaseOrder->task_price) }}</td>
                                 <td>{{ number_format($purchaseOrder->task_price) }}</td>
+                            </tr>
+                            <tr>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                            </tr>
+                            <tr>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                            </tr>
+                            <tr>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                            </tr>
+                            <tr>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                            </tr>
+                            <tr>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                            </tr>
+                            <tr>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
                             </tr>
                             <tr>
                                 <td></td>

--- a/resources/views/partner/document/invoice/show.blade.php
+++ b/resources/views/partner/document/invoice/show.blade.php
@@ -141,10 +141,8 @@
 <div class="main-wrapper">
 	<div class="title-container">
 		<h3>請求書プレビュー</h3>
-
-		<button id="print_btn" type="button">印刷</button>
+		<button id="print_btn" type="button">プリント</button>
 	</div>
-
 	<div id="print" class="document-container A4">
 		<!-- 印刷用 -->
 		<div class="pageout">
@@ -197,6 +195,24 @@
 									<td>{{ number_format($requestExpence->total) }}</td>
 								</tr>
 							@endforeach
+							<tr>
+								<td></td>
+								<td></td>
+								<td></td>
+								<td></td>
+							</tr>
+							<tr>
+								<td></td>
+								<td></td>
+								<td></td>
+								<td></td>
+							</tr>
+							<tr>
+								<td></td>
+								<td></td>
+								<td></td>
+								<td></td>
+							</tr>
 							<tr>
 								<td></td>
 								<td></td>
@@ -313,6 +329,24 @@
 								<td>{{ number_format($requestExpence->total) }}</td>
 							</tr>
 						@endforeach
+						<tr>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+						</tr>
+						<tr>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+						</tr>
+						<tr>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+						</tr>
 						<tr>
 							<td></td>
 							<td></td>


### PR DESCRIPTION
## 概要
<!-- 変更の目的、内容等 -->
company側の請求書・発注書、partner側の請求書のプレビューページをA4サイズにした際、下部にできるだけ空白ができないようにするため、内訳の罫線を追加。
また、それぞれのページがある程度デザイン揃うように修正。
(機密保持契約書もPDF化実装ページに当たるかと思いますが、文字のみで罫線存在しないため、空白埋めるのが難しく変更していません。)

## 確認項目
<!-- 動作確認でチェックしてもらいたい項目 -->

## 補足
<!-- レビュワーに見てもらいたい点等 -->
